### PR TITLE
Fix AirPlay pair and stream under pyatv 0.17

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ from fastapi import Body, FastAPI, File, Request, UploadFile, WebSocket, WebSock
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from pyatv.interface import MediaMetadata
+from pyatv.storage.file_storage import FileStorage
 
 import catalog as cat
 import exporter as exp
@@ -497,6 +498,10 @@ class AppState:
         # Strong refs to fire-and-forget asyncio tasks so they're not GC'd
         # mid-flight. Tasks remove themselves via add_done_callback.
         self.bg_tasks: set = set()
+        # pyatv 0.17 needs an explicit FileStorage handed to scan() and pair()
+        # so that saved credentials get attached to the conf objects we then
+        # pass to pyatv.connect(). Loaded once at startup and reused.
+        self.atv_storage: FileStorage | None = None
         self.album_encoding = {
             "in_progress": False,
             "album_id": None,
@@ -1235,11 +1240,16 @@ async def _run_stream_inner(targets, audio_device_index, volume):
         artwork= _art_jpeg(np) if np else None,
     )
 
-    # Set up AirPlay devices (if any)
+    # Set up AirPlay devices (if any). storage= attaches saved
+    # credentials to the conf services so pyatv.connect doesn't have
+    # to re-pair every time.
     confs = []
     if airplay_targets:
-        found      = await pyatv.scan(main_loop, timeout=7,
-                                      protocol=pyatv.Protocol.AirPlay)
+        if state.atv_storage is not None:
+            await state.atv_storage.load()
+        found = await pyatv.scan(
+            main_loop, timeout=7, storage=state.atv_storage,
+        )
         id_to_conf = {d.identifier: d for d in found}
         confs      = [id_to_conf[t["id"]] for t in airplay_targets if t["id"] in id_to_conf]
 
@@ -1471,6 +1481,25 @@ async def lifespan(app: FastAPI):
     # Backfill any missing track durations from MusicBrainz (non-blocking)
     loop = asyncio.get_event_loop()
     state.loop = loop
+
+    # Load saved AirPlay credentials so streaming can authenticate without
+    # asking the user to re-pair every time. pyatv 0.17 only attaches creds
+    # to conf objects when a storage is explicitly passed to scan().
+    try:
+        for _creds_path in ("/home/listen/.pyatv.conf", "/root/.pyatv.conf"):
+            if os.path.exists(_creds_path):
+                state.atv_storage = FileStorage(_creds_path, loop)
+                await state.atv_storage.load()
+                print(f"[pyatv] Loaded credential storage from {_creds_path}")
+                break
+        else:
+            # Fall back to default location, creating an empty storage if needed
+            state.atv_storage = FileStorage.default_storage(loop)
+            await state.atv_storage.load()
+    except Exception as e:
+        print(f"[pyatv] Could not load credential storage: {e}")
+        state.atv_storage = None
+
     loop.run_in_executor(None, cat.backfill_all_missing_durations)
     yield
     if state.stop_event:
@@ -1538,42 +1567,44 @@ async def service_worker():
 
 @app.get("/api/scan")
 async def scan_devices():
-    found = await pyatv.scan(asyncio.get_event_loop(), timeout=7,
-                              protocol=pyatv.Protocol.AirPlay)
+    # Scan WITHOUT a protocol filter so every service (RAOP, AirPlay,
+    # Companion) is populated on each conf. Pass storage= so saved
+    # credentials are attached to the conf services. Together these
+    # let us compute needs_pairing correctly per service.
+    if state.atv_storage is not None:
+        await state.atv_storage.load()
+    found = await pyatv.scan(
+        asyncio.get_event_loop(),
+        timeout=7,
+        storage=state.atv_storage,
+    )
     hidden = set(state.settings.get("hidden_devices", []))
-    # Load stored credentials to check which devices are already paired
-    import os
-    _creds_path = next((p for p in ["/root/.pyatv.conf", "/home/listen/.pyatv.conf"]
-                        if os.path.exists(p)), None)
-    _creds_data = {}
-    if _creds_path:
-        try:
-            with open(_creds_path) as _cf:
-                _raw = json.loads(_cf.read())
-            # Build set of identifiers that have RAOP or AirPlay credentials
-            for _entry in _raw if isinstance(_raw, list) else _raw.get("devices", []):
-                _protos = _entry.get("protocols", {})
-                _has = any(_protos.get(p, {}).get("credentials") for p in ("raop", "airplay"))
-                if _has:
-                    for _ident in _entry.get("identifiers", []):
-                        _creds_data[_ident] = True
-        except Exception:
-            pass
-
     custom_names = state.settings.get("device_names", {})
     state.available_devices = []
     for d in found:
-        raop    = d.get_service(pyatv.Protocol.RAOP)
-        needs   = raop and str(getattr(raop, "pairing", "")).endswith("Mandatory")
-        paired  = (not needs) or any(_creds_data.get(i) for i in [d.identifier, *list(d.all_identifiers)])
+        # A device needs pairing if RAOP (the protocol we stream with)
+        # has Mandatory pairing and we don't already have credentials.
+        raop = d.get_service(pyatv.Protocol.RAOP)
+        needs_pair = bool(
+            raop and str(getattr(raop, "pairing", "")).endswith("Mandatory")
+            and not raop.credentials
+        )
+        # "paired" is true if every Mandatory protocol on this device has
+        # credentials. RAOP is what we stream with; AirPlay/Companion are
+        # often required alongside it on modern tvOS.
+        all_mandatory_paired = True
+        for svc in d.services:
+            if str(getattr(svc, "pairing", "")).endswith("Mandatory") and not svc.credentials:
+                all_mandatory_paired = False
+                break
         state.available_devices.append({
             "id":       d.identifier,
             "name":     d.name,
             "custom_name": custom_names.get(d.identifier),
             "address":  str(d.address),
             "hidden":   d.identifier in hidden,
-            "needs_pairing": bool(needs),
-            "paired":   paired,
+            "needs_pairing": needs_pair,
+            "paired":   all_mandatory_paired,
         })
     return {"devices": state.available_devices + _get_local_outputs()}
 
@@ -1596,14 +1627,19 @@ async def pair_start(device_id: str, body: dict | None = None):
     protocol = proto_map.get(protocol_name, pyatv.Protocol.RAOP)
 
     loop = asyncio.get_event_loop()
-    found = await pyatv.scan(loop, timeout=7, identifier=device_id,
-                              protocol=pyatv.Protocol.AirPlay)
+    # No protocol filter: we need RAOP / AirPlay / Companion service
+    # objects on the conf so pyatv.pair can pick the right one.
+    if state.atv_storage is not None:
+        await state.atv_storage.load()
+    found = await pyatv.scan(
+        loop, timeout=7, identifier=device_id, storage=state.atv_storage,
+    )
     if not found:
         return {"ok": False, "error": "Device not found on network"}
     conf = found[0]
 
     try:
-        pairing = await pyatv.pair(conf, protocol, loop)
+        pairing = await pyatv.pair(conf, protocol, loop, storage=state.atv_storage)
         await pairing.begin()
     except Exception as e:
         return {"ok": False, "error": str(e)}
@@ -1648,20 +1684,15 @@ async def pair_pin(device_id: str, body: dict | None = None):
 
     state.pairing_sessions.pop(device_id, None)
 
-    # Save credentials to both locations so they persist across restarts
-    for creds_path in ["/root/.pyatv.conf", "/home/listen/.pyatv.conf"]:
+    # pyatv.pair was given state.atv_storage, so the newly issued
+    # credentials are already attached to the in-memory storage. All
+    # that's left is to flush them to disk.
+    if state.atv_storage is not None:
         try:
-            from pyatv.storage.file_storage import FileStorage
-            try:
-                storage = FileStorage(creds_path, asyncio.get_event_loop())
-            except TypeError:
-                storage = FileStorage(creds_path)
-            await storage.load()
-            storage.save_device(conf)
-            await storage.flush()
-            print(f"[pair] Credentials saved to {creds_path}")
+            await state.atv_storage.save()
+            print("[pair] Credentials saved")
         except Exception as e:
-            print(f"[pair] Could not save to {creds_path}: {e}")
+            print(f"[pair] Could not save credential storage: {e}")
 
     protocol_name = session["protocol"]
     # Check if more protocols need pairing
@@ -4404,11 +4435,14 @@ async def _run_playback(album_id: int, targets: list[dict], volume: int,
     if len(bluetooth_targets) > 1:
         bluetooth_targets = bluetooth_targets[:1]
 
-    # Scan and connect to AirPlay devices
+    # Scan and connect to AirPlay devices. storage= so saved creds attach.
     confs = []
     if airplay_targets:
-        found      = await pyatv.scan(main_loop, timeout=7,
-                                      protocol=pyatv.Protocol.AirPlay)
+        if state.atv_storage is not None:
+            await state.atv_storage.load()
+        found = await pyatv.scan(
+            main_loop, timeout=7, storage=state.atv_storage,
+        )
         id_to_conf = {d.identifier: d for d in found}
         confs      = [id_to_conf[t["id"]] for t in airplay_targets if t["id"] in id_to_conf]
 
@@ -4613,7 +4647,11 @@ async def _run_playback_queue(album_id: int, album_info: dict,
 
     confs = []
     if airplay_targets:
-        found = await pyatv.scan(main_loop, timeout=7, protocol=pyatv.Protocol.AirPlay)
+        if state.atv_storage is not None:
+            await state.atv_storage.load()
+        found = await pyatv.scan(
+            main_loop, timeout=7, storage=state.atv_storage,
+        )
         id_to_conf = {d.identifier: d for d in found}
         confs = [id_to_conf[t["id"]] for t in airplay_targets if t["id"] in id_to_conf]
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -5310,7 +5310,30 @@ async function stopStream(){
     if(bs)bs.disabled=false;if(bt)bt.disabled=false;
   }
 }
-async function pairDevice(did){const r=await fetch('/api/pair',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({device_id:did,protocol:'raop'})}).then(r=>r.json());if(r.ok){showToast('Check device for PIN');const pin=prompt('Enter PIN:');if(pin){const f=await fetch('/api/pair',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({device_id:did,protocol:'raop',pin})}).then(r=>r.json());if(f.ok){showToast('Paired!');scanDevices()}else showError(f.error||'Failed')}}else showError(r.error||'Failed')}
+async function pairOneProtocol(did,proto){
+  const enc=encodeURIComponent(did);
+  const s=await fetch(`/api/devices/${enc}/pair/start`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({protocol:proto})}).then(r=>r.json());
+  if(!s.ok){showError(s.error||`Pair start (${proto}) failed`);return null}
+  showToast(`Check ${proto.toUpperCase()} device for PIN`);
+  const pin=prompt(`Enter PIN shown on the device (${proto.toUpperCase()}):`);
+  if(!pin){await fetch(`/api/devices/${enc}/pair/cancel`,{method:'POST'}).catch(()=>{});return null}
+  const f=await fetch(`/api/devices/${enc}/pair/pin`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pin})}).then(r=>r.json());
+  if(!f.ok){showError(f.error||`Pair finish (${proto}) failed`);return null}
+  return f;
+}
+async function pairDevice(did){
+  // Some Apple TVs require pairing RAOP and AirPlay both. Server tells
+  // us via remaining_protocols which still need it.
+  let r=await pairOneProtocol(did,'raop');
+  if(!r)return;
+  const remaining=(r.remaining_protocols||[]);
+  for(const proto of remaining){
+    const r2=await pairOneProtocol(did,proto);
+    if(!r2)return;
+  }
+  showToast('Paired!');
+  scanDevices();
+}
 function renderHiddenDevices(devs){const l=document.getElementById('hidden-device-list');if(!devs||!devs.length){l.innerHTML='<div style="color:var(--muted);font-size:0.82rem">Scan to manage</div>';return}l.innerHTML=devs.map(d=>`<label class="device-item" style="gap:0.5rem"><input type="checkbox" ${d.hidden?'checked':''} onchange="toggleHidden('${d.id}',this.checked)" style="accent-color:var(--rust)"><span style="font-size:0.82rem">${esc(d.name)}${d.hidden?' (hidden)':''}</span></label>`).join('')}
 async function toggleHidden(did,hide){await fetch('/api/device/hide',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({device_id:did,hidden:hide})})}
 async function saveAutoStreamSettings(){const en=document.getElementById('auto-stream-enabled').checked,sel=document.getElementById('auto-stream-device-select'),opt=sel.options[sel.selectedIndex],dev=opt&&opt.value?{id:opt.value,name:opt.textContent}:null;await fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({auto_stream_enabled:en,auto_stream_device:dev})});document.getElementById('auto-stream-status').textContent=en&&dev?`Auto-streaming to: ${dev.name}`:''}


### PR DESCRIPTION
Four bugs surfaced by the pyatv 0.17 bump that together meant the in-UI pairing flow was broken and streaming had to re-pair every time.

1. **`pyatv.scan()` now needs `storage=`** to attach saved credentials to the returned conf services. All scan call sites in the streaming and playback paths now pass it. `AppState` loads a `FileStorage` once at lifespan startup and reuses it.
2. **`/api/scan` and `/api/devices/{id}/pair/start` were filtering by `protocol=AirPlay`**, which dropped the RAOP service object on the returned conf. That made `needs_pairing` always false in the device list (UI never showed a Pair button) and made `pair_start` fail with `no service available for Protocol.RAOP`. Filter removed.
3. **`/api/devices/{id}/pair/pin` used the old `FileStorage.save_device()` and `storage.flush()` APIs** which were removed in pyatv 0.17. Replaced with `pair(..., storage=storage)` plus `storage.save()`.
4. **Frontend `pairDevice()` posted to `/api/pair`**, which never existed. Switched to the real endpoints (`/pair/start` + `/pair/pin`) and walks `remaining_protocols` so a single click pairs both RAOP and AirPlay on tvOS devices that require both.

The `paired` / `needs_pairing` computation also stops reading `~/.pyatv.conf` directly. It now uses `conf.services[*].credentials`, which is what the file-driven check was approximating anyway.

Tested on the Pi: Living Room Apple TV pairing now sticks across restarts and the streaming code picks up the saved credentials. Lint and compile are green.