### PR TITLE
Fix choppy /live.mp3 by accumulating leftover PCM bytes

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,9 +55,10 @@ def _capture_channels(device_index=None) -> int:
     except Exception:
         return 2  # safe stereo fallback
 BITS          = 16
-BLOCK_SIZE    = 8192   # larger blocks = fewer callbacks = less overflow on Pi
-                       # (the live MP3 encoder re-chunks internally to MP3 frame
-                       # boundaries, so capture block size is independent of that)
+BLOCK_SIZE    = 8192   # larger blocks = fewer callbacks = less overflow on Pi.
+                       # The live MP3 broadcaster accumulates leftover bytes
+                       # across put() calls, so this can be any size; the
+                       # encoder always gets aligned MP3 frames downstream.
 INPUT_LATENCY = 0.5    # seconds: large ALSA buffer absorbs USB timing jitter
                        # (Scarlett 2i2 4th Gen triggers retire_capture_urb warnings
                        # on the Pi's USB host controller; a bigger buffer keeps the
@@ -262,8 +263,14 @@ class LiveMP3Broadcaster:
         self._proc = None
         self._running = threading.Event()
         self._input_lock = threading.Lock()
-        # Further increase buffer size for more robust streaming (e.g., 16384 chunks)
+        # 16384 chunks ~= ~7 minutes at PCM_CHUNK_SECS. Generous buffer
+        # for transient capture/encode stalls.
         self._input_chunks = collections.deque(maxlen=16384)
+        # Leftover bytes from previous put() call that didn't align to a
+        # full PCM_CHUNK_BYTES boundary. Saved so the next put() can
+        # complete a full chunk instead of the feed loop padding with
+        # silence (which is audibly choppy).
+        self._partial_input = b""
         # Pre-fill input buffer with silence to avoid underruns at startup
         silence = b"\x00" * self.PCM_CHUNK_BYTES
         for _ in range(128):
@@ -345,6 +352,7 @@ class LiveMP3Broadcaster:
         self._running.clear()
         with self._input_lock:
             self._input_chunks.clear()
+            self._partial_input = b""
 
         proc = self._proc
         self._proc = None
@@ -371,9 +379,19 @@ class LiveMP3Broadcaster:
             if not self.is_running():
                 return
         with self._input_lock:
+            # Combine any leftover bytes from the previous call so chunks
+            # always align to PCM_CHUNK_BYTES (one MP3 frame at 44.1k
+            # stereo s16). Without this, capture blocks that aren't a
+            # multiple of PCM_CHUNK_BYTES leave a partial chunk in the
+            # queue, which the feed loop then pads with silence: that
+            # silence injection is exactly what makes /live.mp3 sound
+            # choppy when BLOCK_SIZE != 4608.
+            data = self._partial_input + pcm_bytes
             chunk = self.PCM_CHUNK_BYTES
-            for i in range(0, len(pcm_bytes), chunk):
-                self._input_chunks.append(pcm_bytes[i:i + chunk])
+            full_count = len(data) // chunk
+            for i in range(full_count):
+                self._input_chunks.append(data[i * chunk:(i + 1) * chunk])
+            self._partial_input = data[full_count * chunk:]
 
     def register_client(self) -> int:
         with self._clients_lock:


### PR DESCRIPTION
## The bug

The live MP3 broadcaster splits incoming PCM into 4608-byte chunks (one MP3 frame at 44.1k stereo s16) for ffmpeg. When the capture `BLOCK_SIZE` isn't a clean multiple of 4608, each `put()` leaves a partial chunk on the deque. The feed loop then pulls that partial and **pads it with silence** to make a full frame, injecting audible silence into the stream.

At `BLOCK_SIZE=8192` this fires every callback: 8192 % 4608 = 3584 bytes leftover, padded with 1024 bytes of zeros. About **5.8 ms of silence every 46 ms** of audio. That's the choppiness.

## The history

@thereal-partyshark worked around this in #19 by setting `BLOCK_SIZE` to 4608 — at that block size there are never leftovers and never silence injection. The post-merge cleanup undid that with an argument about the encoder re-chunking internally. **They were right and I was wrong.** The encoder does re-chunk, but the broadcaster pads partials before they even reach the encoder. Their fix was masking my bug.

## The real fix

`put()` now keeps leftover bytes in `_partial_input` and prepends them to the next call. The queue only ever sees full chunks. The feed loop's silence-padding path becomes unreachable (left in as defense).

`BLOCK_SIZE` stays at 8192 so we don't trade off USB stability on the Scarlett 2i2 for stream smoothness. The fix is correct regardless of what `BLOCK_SIZE` is set to.

Also resets `_partial_input` on `stop()` so a restart doesn't carry stale audio.