### PR TITLE
Make LiveMP3Broadcaster.stop() a hard stop so service shutdown drains

### DIFF
--- a/main.py
+++ b/main.py
@@ -305,7 +305,11 @@ class LiveMP3Broadcaster:
             self.start()
 
     def start(self):
-        self.stop()
+        # Tear down any previous encoder without flipping enabled. start()
+        # may be called from configure() right after the user toggles the
+        # stream on, and we don't want our own cleanup to immediately
+        # disable us again.
+        self._teardown_encoder()
         cmd = [
             "ffmpeg",
             "-hide_banner",
@@ -349,6 +353,19 @@ class LiveMP3Broadcaster:
         print(f"[http-stream] Encoder started at {self.bitrate_kbps} kbps")
 
     def stop(self):
+        # Public stop: hard stop. Sets enabled=False so put() will
+        # early-return instead of auto-restarting the encoder via its
+        # auto-recovery path. Without this, an audio callback that fires
+        # during shutdown will re-spawn ffmpeg and block systemd from
+        # terminating the service. configure() resets enabled=True when
+        # the user turns the stream back on in Settings.
+        self.enabled = False
+        self._teardown_encoder()
+
+    def _teardown_encoder(self):
+        # Internal cleanup: tears down ffmpeg and drains queues without
+        # touching `enabled`. Used by both start() (clean slate before
+        # relaunch) and stop() (hard shutdown).
         self._running.clear()
         with self._input_lock:
             self._input_chunks.clear()


### PR DESCRIPTION
Caught during the #29 deploy: the service spent ~90 seconds in `deactivating` before systemd's timeout expired and SIGKILL'd it. `journalctl` showed the encoder being stopped and immediately restarted on a loop.

## Cause

`LiveMP3Broadcaster.put()` has an auto-restart path that re-spawns ffmpeg whenever `enabled=True` but `is_running()` is false. During shutdown:

1. Lifespan calls `state.live_mp3.stop()`, which cleared `_running` and killed the subprocess but left `enabled=True`.
2. Audio callback thread hadn't been signaled to exit yet, so it kept firing.
3. Each callback called `put()`, which saw `enabled=True` + not running and re-spawned ffmpeg.
4. Repeat until SIGKILL.

## Fix

`stop()` now flips `enabled=False` first, so `put()` early-returns instead of re-launching. The subprocess teardown is moved into `_teardown_encoder()` so `start()` can reuse it without flipping `enabled` (which would defeat configure's flow).

`configure(enabled=True, ...)` sets `enabled=True` before calling `start()`, so the user-facing on/off flow is unchanged.