### PR TITLE
Add track-level shuffle across the whole library

### DIFF
--- a/catalog.py
+++ b/catalog.py
@@ -1967,6 +1967,48 @@ def get_album_audio(album_id: int) -> list[dict]:
         db.close()
 
 
+def get_all_playable_tracks() -> list[dict]:
+    """Return every track that can be played right now.
+
+    A track is "playable" when its album has a recorded side FLAC for
+    that track's side, AND the track has start_secs / end_secs set so
+    we can extract just its portion of the side audio.
+
+    Returns one row per track with everything the player needs to build
+    a single-track PlaylistEntry: the file path, side, the track's
+    in-file timestamps, and basic album metadata (for the Now Playing
+    panel). Soft-deleted albums (deleted_at IS NOT NULL) are excluded.
+    """
+    db = get_db()
+    try:
+        rows = db.execute("""
+            SELECT
+                t.id            AS track_id,
+                t.title         AS track_title,
+                t.track_number  AS track_number,
+                t.side          AS side,
+                t.start_secs    AS start_secs,
+                t.end_secs      AS end_secs,
+                a.id            AS album_id,
+                a.title         AS album_title,
+                a.artist        AS album_artist,
+                a.user_artwork_path AS user_artwork_path,
+                a.artwork_path  AS artwork_path,
+                aa.file_path    AS audio_path,
+                aa.duration_secs AS side_duration_secs
+            FROM tracks t
+            JOIN albums a       ON a.id  = t.album_id
+            JOIN album_audio aa ON aa.album_id = t.album_id AND aa.side = t.side
+            WHERE (a.deleted_at IS NULL OR a.deleted_at = '')
+              AND t.start_secs IS NOT NULL
+              AND t.end_secs   IS NOT NULL
+              AND t.end_secs > t.start_secs
+        """).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        db.close()
+
+
 def get_album_audio_by_id(audio_id: int) -> dict | None:
     """Get a single album audio record by its ID."""
     db = get_db()

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import concurrent.futures
 import json
 import math
 import os
+import random
 import shutil
 import socket
 import struct
@@ -2740,8 +2741,6 @@ async def generate_collage():
     loop = asyncio.get_event_loop()
 
     def _build():
-        import random
-
         from PIL import Image as PILImage
 
         db = cat.get_db()
@@ -5007,6 +5006,92 @@ async def player_play_queue(body: dict):
 
     state.player_task = asyncio.create_task(
         _run_playback_queue(first_aid, first_info, combined_playlist, targets, volume)
+    )
+    return {"ok": True, "queued": len(combined_playlist)}
+
+
+@app.post("/api/player/play-shuffle-tracks")
+async def player_play_shuffle_tracks(body: dict):
+    """
+    Play every track in the catalog in random order, one track at a time.
+
+    This is distinct from the existing album-shuffle: instead of shuffling
+    whole albums and playing them through, we treat each track as its own
+    playlist entry (using PlaylistEntry.source_offset_secs /
+    source_duration_secs to bound playback to just that track's slice of
+    its side FLAC), then shuffle the list.
+
+    body: { devices?: [{id, name}], volume?: int, limit?: int }
+    """
+    targets = body.get("devices") or state.settings.get("saved_devices", [])
+    if not targets:
+        return {"ok": False, "error": "No AirPlay devices selected"}
+    volume = body.get("volume", state.settings.get("volume", 80))
+
+    tracks = cat.get_all_playable_tracks()
+    if not tracks:
+        return {"ok": False, "error": "No recorded tracks available"}
+
+    random.shuffle(tracks)
+    limit = body.get("limit")
+    if isinstance(limit, int) and limit > 0:
+        tracks = tracks[:limit]
+
+    combined_playlist = []
+    for t in tracks:
+        start = float(t["start_secs"])
+        end   = float(t["end_secs"])
+        dur   = max(0.0, end - start)
+        if dur <= 0:
+            continue
+        # Single-track entry: tracks list has just this one track, with
+        # entry-local timing (0 -> dur). Player will start ffmpeg with
+        # -ss start -t dur so only this track's audio is decoded.
+        track_obj = {
+            "id":           t["track_id"],
+            "title":        t["track_title"],
+            "artist":       t.get("album_artist"),
+            "track_number": t.get("track_number"),
+            "start_secs":   0.0,
+            "end_secs":     dur,
+        }
+        combined_playlist.append(plr.PlaylistEntry(
+            audio_path=t["audio_path"],
+            side=t.get("side") or "",
+            duration_secs=dur,
+            tracks=[track_obj],
+            album_id=t["album_id"],
+            album_title=t["album_title"],
+            album_artist=t["album_artist"],
+            artwork_path=t.get("user_artwork_path") or t.get("artwork_path"),
+            source_offset_secs=start,
+            source_duration_secs=dur,
+        ))
+
+    if not combined_playlist:
+        return {"ok": False, "error": "No playable tracks (all missing boundaries)"}
+
+    # Stop streaming / listen / existing playback (same pattern as play-queue)
+    if state.is_streaming:
+        if state.stop_event:
+            state.stop_event.set()
+        if state.stream_task:
+            state.stream_task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await state.stream_task
+            state.stream_task = None
+    _stop_listen_mode()
+    await asyncio.sleep(0.3)
+    await _stop_playback()
+
+    first = combined_playlist[0]
+    base_info = {
+        "id":     first.album_id,
+        "title":  first.album_title,
+        "artist": first.album_artist,
+    }
+    state.player_task = asyncio.create_task(
+        _run_playback_queue(first.album_id, base_info, combined_playlist, targets, volume)
     )
     return {"ok": True, "queued": len(combined_playlist)}
 

--- a/player.py
+++ b/player.py
@@ -48,12 +48,26 @@ SILENCE_FRAMES = int(SAMPLE_RATE * SILENCE_MS / 1000)
 # ── Playlist Entry ───────────────────────────────────────────────────────────
 
 class PlaylistEntry:
-    """One side of an album (one FLAC file)."""
+    """One playable segment.
+
+    By default an entry represents one whole side of an album (one FLAC
+    file played from start to end). For track-level shuffle and similar,
+    pass source_offset_secs and source_duration_secs to make an entry
+    represent a single track range within a side's FLAC; ffmpeg will be
+    started with -ss source_offset_secs -t source_duration_secs so the
+    decoded PCM is exactly that track and nothing else.
+
+    Position semantics inside the player are entry-local: self._position
+    counts from 0 at the start of the entry, regardless of where the
+    entry sits within its source file.
+    """
 
     def __init__(self, audio_path: str, side: str, duration_secs: float,
                  tracks: list[dict], album_id: int | None = None,
                  album_title: str | None = None, album_artist: str | None = None,
-                 artwork_path: str | None = None):
+                 artwork_path: str | None = None,
+                 source_offset_secs: float = 0.0,
+                 source_duration_secs: float | None = None):
         self.audio_path    = audio_path
         self.side          = side
         self.duration_secs = duration_secs
@@ -65,6 +79,10 @@ class PlaylistEntry:
         self.album_title   = album_title
         self.album_artist  = album_artist
         self.artwork_path  = artwork_path
+        # Where in audio_path this entry begins, and how much of it to
+        # consume. None means "play to natural EOF" (full-side behavior).
+        self.source_offset_secs   = float(source_offset_secs or 0.0)
+        self.source_duration_secs = source_duration_secs
 
 
 # ── Player ───────────────────────────────────────────────────────────────────
@@ -351,15 +369,23 @@ class Player:
 
     # ── Internal: ffmpeg Decode ──────────────────────────────────────────────
 
-    def _start_ffmpeg(self, audio_path: str, start_secs: float = 0.0) -> bool:
-        """Start ffmpeg decoding FLAC → raw s16le PCM pipe."""
+    def _start_ffmpeg(self, audio_path: str, start_secs: float = 0.0,
+                      duration_secs: float | None = None) -> bool:
+        """Start ffmpeg decoding FLAC → raw s16le PCM pipe.
+
+        start_secs and duration_secs are absolute to the source file:
+        ffmpeg will seek to start_secs and emit at most duration_secs of
+        audio. duration_secs=None plays to natural EOF.
+        """
         self._kill_ffmpeg()
 
         cmd = ["ffmpeg", "-hide_banner", "-loglevel", "error"]
         if start_secs > 0:
             cmd += ["-ss", f"{start_secs:.3f}"]
+        cmd += ["-i", audio_path]
+        if duration_secs is not None and duration_secs > 0:
+            cmd += ["-t", f"{duration_secs:.3f}"]
         cmd += [
-            "-i", audio_path,
             "-f", "s16le",
             "-acodec", "pcm_s16le",
             "-ar", str(SAMPLE_RATE),
@@ -406,9 +432,13 @@ class Player:
         next_entry = self.playlist[next_idx]
         if not Path(next_entry.audio_path).exists():
             return
-        cmd = [
-            "ffmpeg", "-hide_banner", "-loglevel", "error",
-            "-i", next_entry.audio_path,
+        cmd = ["ffmpeg", "-hide_banner", "-loglevel", "error"]
+        if next_entry.source_offset_secs > 0:
+            cmd += ["-ss", f"{next_entry.source_offset_secs:.3f}"]
+        cmd += ["-i", next_entry.audio_path]
+        if next_entry.source_duration_secs is not None and next_entry.source_duration_secs > 0:
+            cmd += ["-t", f"{next_entry.source_duration_secs:.3f}"]
+        cmd += [
             "-f", "s16le", "-acodec", "pcm_s16le",
             "-ar", str(SAMPLE_RATE), "-ac", str(CHANNELS),
             "pipe:1",
@@ -529,11 +559,19 @@ class Player:
             # If we already have ffmpeg running (from gapless pre-start), use it
             if self._ffmpeg and self._ffmpeg.poll() is None:
                 pass  # Already running from gapless swap
-            elif not self._start_ffmpeg(entry.audio_path, self._position):
-                print(f"[player] Failed to start ffmpeg for {entry.audio_path}")
-                self._side_idx += 1
-                self._position = 0.0
-                continue
+            else:
+                # Translate entry-local position into source-file timestamps.
+                # For full-side entries source_offset_secs=0 and duration=None,
+                # so this matches the original "seek to position in FLAC" behavior.
+                src_start = entry.source_offset_secs + self._position
+                src_dur = None
+                if entry.source_duration_secs is not None:
+                    src_dur = max(0.0, entry.source_duration_secs - self._position)
+                if not self._start_ffmpeg(entry.audio_path, src_start, src_dur):
+                    print(f"[player] Failed to start ffmpeg for {entry.audio_path}")
+                    self._side_idx += 1
+                    self._position = 0.0
+                    continue
 
             # Pre-start ffmpeg for the next side (gapless transition)
             self._prestart_next_side()
@@ -597,7 +635,12 @@ class Player:
                             except Exception:
                                 pass
                             self._ffmpeg = None
-                        if not self._start_ffmpeg(entry.audio_path, target):
+                        # Translate entry-local target into source-file coords
+                        src_start = entry.source_offset_secs + target
+                        src_dur = None
+                        if entry.source_duration_secs is not None:
+                            src_dur = max(0.0, entry.source_duration_secs - target)
+                        if not self._start_ffmpeg(entry.audio_path, src_start, src_dur):
                             break
                         # Short fade for seeks (just anti-click, not needle drop)
                         self._fade_in_remaining = SILENCE_FRAMES

--- a/templates/index.html
+++ b/templates/index.html
@@ -1997,7 +1997,8 @@
   <button class="header-btn" id="btn-select" onclick="toggleMultiSelect()" title="Select" style="display:none">☑</button>
   <button class="header-btn" onclick="showStats()" title="Stats &amp; history"><svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><rect x="2" y="10" width="3" height="6" rx="0.5"/><rect x="7.5" y="6" width="3" height="10" rx="0.5"/><rect x="13" y="2" width="3" height="14" rx="0.5"/></svg></button>
   <button class="header-btn" onclick="togglePlaylistsPanel()" title="Playlists">&#9835;</button>
-  <button class="header-btn" onclick="shufflePlay()" title="Shuffle play"><svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2 13h3l4-8h3"/><path d="M2 5h3l4 8h3"/><path d="M14 3l3 2.5-3 2.5"/><path d="M14 10l3 2.5-3 2.5"/></svg></button>
+  <button class="header-btn" onclick="shufflePlay()" title="Shuffle albums (queues whole albums in random order)"><svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2 13h3l4-8h3"/><path d="M2 5h3l4 8h3"/><path d="M14 3l3 2.5-3 2.5"/><path d="M14 10l3 2.5-3 2.5"/></svg></button>
+  <button class="header-btn" onclick="shuffleTracks()" title="Shuffle tracks (mixes individual songs from every album)"><svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="13.5" r="1.5"/><path d="M6.5 13.5V4l5-1v9"/><circle cx="11.5" cy="12" r="1.5"/><path d="M14.5 3l1.5 1.2-1.5 1.2"/></svg></button>
   <button class="header-btn" onclick="showAddForm()" title="Add record" style="font-size:1.5rem;font-weight:700;line-height:1">+</button>
   <button class="header-btn" onclick="showSettings()" title="Settings">⚙</button>
   <div id="sort-panel-backdrop" class="sort-panel-backdrop" onclick="closeSortPanel()"></div>
@@ -3382,6 +3383,28 @@ async function shufflePlay(){
   }
 }
 
+// Track-level shuffle: every track in the catalog, in random order. The
+// server does the shuffle and builds single-track playlist entries; we
+// just need to pick an output device (if not already streaming) and POST.
+async function shuffleTracks(){
+  const anyRecorded=(_catalogAlbums||[]).some(a=>a.audio_count>0);
+  if(!anyRecorded){showToast('No recorded tracks to shuffle');return}
+  if(_isStreaming||_playerActive){
+    const body={devices:_currentDevices,volume:parseInt(document.getElementById('eq-volume').value)};
+    const r=await fetch('/api/player/play-shuffle-tracks',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)}).then(function(r){return r.json()});
+    if(r.ok)showToast('Shuffling '+r.queued+' tracks...');
+    else showError(r.error||'Shuffle failed');
+  }else{
+    // Defer until output picked. Reuse the existing pending-album-ids
+    // hook by setting a sentinel; output picker calls back through
+    // playMultipleAlbums otherwise, so we need a small branch there too.
+    _pendingShuffleTracks=true;
+    _pendingAlbumIds=null;
+    _pendingAlbumId=null;
+    showOutputPicker(null);
+  }
+}
+
 async function toggleAlbumFavorite(id){
   try{
     const r=await fetch(`/api/catalog/${id}/favorite`,{method:'POST'}).then(r=>r.json());
@@ -3395,6 +3418,9 @@ async function toggleAlbumFavorite(id){
 
 // ── Per-Group Play (multi-album queue) ──
 var _pendingAlbumIds=null;
+// Sentinel: when set, the next output-picker selection should kick off
+// the track-level shuffle endpoint instead of normal album playback.
+var _pendingShuffleTracks=false;
 function playGroup(groupKey){
   var field=_viewState.groupBy;
   if(!field)return;
@@ -3591,6 +3617,7 @@ async function pickOutput(idx){
   var aid=_pendingAlbumId;
   var aids=_pendingAlbumIds;
   var trackId=_pendingTrackId;
+  var shuffleTracks=_pendingShuffleTracks;
   closeOutputPicker();
   _lastUsedDevice=dev.id;
   var displayName=dev.custom_name||dev.name;
@@ -3603,19 +3630,27 @@ async function pickOutput(idx){
       var streamResp=await fetch('/api/stream/create',{method:'POST',headers:{'Content-Type':'application/json'}}).then(function(r){return r.json()});
       if(streamResp.ok){
         target.id='browser:'+streamResp.stream_id;
-        startPlayback(aid,aids,target,trackId);
+        startPlayback(aid,aids,target,trackId,shuffleTracks);
       }else{
         showError('Failed to create browser stream')
       }
     })();
     return
   }
-  startPlayback(aid,aids,target,trackId);
+  startPlayback(aid,aids,target,trackId,shuffleTracks);
   if(window._deviceVolumes&&window._deviceVolumes[dev.id]){setTimeout(()=>{document.getElementById('eq-volume').value=window._deviceVolumes[dev.id];sendVolume()},500)}
 }
-function startPlayback(aid,aids,target,trackId){
+function startPlayback(aid,aids,target,trackId,shuffleTracks){
   _currentDevices=[target];
   fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({saved_devices:[target]})});
+  if(shuffleTracks){
+    var vol=parseInt(document.getElementById('eq-volume').value);
+    fetch('/api/player/play-shuffle-tracks',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({devices:[target],volume:vol})}).then(function(r){return r.json()}).then(function(r){
+      if(r.ok)showToast('Shuffling '+r.queued+' tracks...');
+      else showError(r.error||'Shuffle failed');
+    });
+    return;
+  }
   if(_pendingPlaylistEntries){var ent=_pendingPlaylistEntries;_pendingPlaylistEntries=null;playMultipleAlbums(null,[target],ent)}
   else if(aids&&aids.length>1){_pendingAlbumIds=null;playMultipleAlbums(aids,[target])}
   else if(aid){
@@ -3637,7 +3672,7 @@ async function playAlbumTo(id,devices,resume,isBrowser){
     startBrowserAudioStream(streamId);
   }
 }
-function closeOutputPicker(){document.getElementById('output-picker-overlay').classList.remove('open');_pendingAlbumId=null;_pendingAlbumIds=null;_pendingTrackId=null;_pickerAlbumId=null;_pendingPlaylistEntries=null}
+function closeOutputPicker(){document.getElementById('output-picker-overlay').classList.remove('open');_pendingAlbumId=null;_pendingAlbumIds=null;_pendingTrackId=null;_pickerAlbumId=null;_pendingPlaylistEntries=null;_pendingShuffleTracks=false}
 async function rescanOutputDevices(){
   var grid=document.getElementById('output-device-grid');
   grid.innerHTML='<div style="color:var(--muted);font-size:0.82rem">Scanning\u2026</div>';


### PR DESCRIPTION
Adds a second shuffle button next to the existing album-shuffle. Where Library Shuffle queues whole albums in random order, **Shuffle Tracks** mixes individual songs from across every recorded album, like a streaming-service shuffle of the whole catalog.

## How it works

- `PlaylistEntry` gains two optional fields, `source_offset_secs` / `source_duration_secs`. With both set, an entry represents a single track range within a side FLAC instead of the whole side. Defaults preserve existing full-side behavior.
- `_start_ffmpeg` takes an optional `duration_secs` arg and passes `-t <duration>` to ffmpeg so the encoder stops at the track boundary.
- The gapless pre-start path (`_prestart_next_side`) honors the next entry's offset/duration too, so transitions between shuffled tracks stay gapless.
- `catalog.get_all_playable_tracks()` returns every track that has both a recorded side and detected start/end timestamps. Excludes soft-deleted albums.
- New endpoint `POST /api/player/play-shuffle-tracks` shuffles that list, builds single-track playlist entries (each carrying its parent album's title/artist/artwork for the Now Playing panel), and dispatches to the existing `_run_playback_queue` runner.
- UI: a second header button with a distinct icon. Click it from a streaming/playing state and it kicks off the shuffle straight away; click it cold and it routes through the output picker like normal playback does.

The endpoint also accepts an optional `limit` field for a future "shuffle N tracks" variant from the UI.

Lint and compile green.