### PR TITLE
Add library-wide fingerprint rebuild as a background job

### DIFF
--- a/catalog.py
+++ b/catalog.py
@@ -1140,6 +1140,94 @@ def save_track_fingerprints(
     finally:
         db.close()
 
+
+# ── Fingerprint Rebuild (maintenance) ─────────────────────────────────────────
+
+def _extract_track_wav(audio_path: str, start_secs: float, end_secs: float) -> bytes | None:
+    """Decode a single track's PCM slice from a side FLAC and return WAV bytes.
+
+    Used by the rebuild_fingerprints job: we already know exactly where each
+    track lives in its side FLAC, so we ask ffmpeg to seek and emit just
+    that segment as a WAV the fingerprinter can consume.
+    """
+    dur = max(0.0, float(end_secs) - float(start_secs))
+    if dur <= 0:
+        return None
+    cmd = [
+        "ffmpeg", "-hide_banner", "-loglevel", "error", "-nostdin",
+        "-ss", f"{float(start_secs):.3f}",
+        "-i", audio_path,
+        "-t", f"{dur:.3f}",
+        "-f", "wav",
+        "-ar", "44100",
+        "-ac", "2",
+        "-acodec", "pcm_s16le",
+        "pipe:1",
+    ]
+    try:
+        # 60s timeout is generous: even a 7-minute track decodes in under a
+        # few seconds on a Pi 5 because we're not re-encoding.
+        r = subprocess.run(cmd, capture_output=True, timeout=60)
+    except Exception as e:
+        print(f"[catalog] _extract_track_wav: ffmpeg failed: {e}")
+        return None
+    if r.returncode != 0:
+        print(f"[catalog] _extract_track_wav: ffmpeg exit {r.returncode}: "
+              f"{r.stderr.decode('utf-8', 'replace').strip()[:200]}")
+        return None
+    return r.stdout or None
+
+
+def rebuild_track_fingerprints(track_id: int, audio_path: str,
+                               start_secs: float, end_secs: float) -> dict:
+    """Re-extract and persist fingerprints for one track.
+
+    Returns {"ok": bool, "rows": int, "error": str|None}. On success, the
+    track's existing fingerprint rows are replaced inside save_track_fingerprints.
+    """
+    if not os.path.exists(audio_path):
+        return {"ok": False, "rows": 0, "error": "audio_path missing"}
+    wav = _extract_track_wav(audio_path, start_secs, end_secs)
+    if not wav:
+        return {"ok": False, "rows": 0, "error": "extract failed or empty"}
+    fp = fingerprint_wav(wav)
+    if not fp:
+        return {"ok": False, "rows": 0, "error": "fpcalc failed or too quiet"}
+    raw_ints, _compressed, duration = fp
+    rows = save_track_fingerprints(track_id, raw_ints, duration)
+    if rows <= 0:
+        return {"ok": False, "rows": 0, "error": "save_track_fingerprints failed"}
+    return {"ok": True, "rows": rows, "error": None}
+
+
+def backup_fingerprints_to(path: str) -> int:
+    """Dump every row of the fingerprints table to a JSON file at `path`.
+
+    Called before a library-wide rebuild so the operation is reversible if
+    something goes catastrophically wrong. Returns the number of rows dumped.
+    """
+    db = get_db()
+    try:
+        rows = db.execute(
+            "SELECT id, track_id, fingerprint, duration FROM fingerprints"
+        ).fetchall()
+        out = [
+            {
+                "id":          r["id"],
+                "track_id":    r["track_id"],
+                "fingerprint": r["fingerprint"],  # already JSON-encoded text
+                "duration":    r["duration"],
+            }
+            for r in rows
+        ]
+    finally:
+        db.close()
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"rows": out}, f)
+    print(f"[catalog] Backed up {len(out)} fingerprint rows to {path}")
+    return len(out)
+
+
 # ── Play Logging ──────────────────────────────────────────────────────────────
 
 def log_play(track_id: int, album_id: int):

--- a/main.py
+++ b/main.py
@@ -547,6 +547,21 @@ class AppState:
             "ok": None,
             "message": "",
         }
+        # State for the "rebuild every track's fingerprints" maintenance job.
+        # Driven by /api/maintenance/rebuild-fingerprints; broadcast to the
+        # UI over the rebuild_fingerprints_progress WS event.
+        self.rebuild_fp = {
+            "in_progress":  False,
+            "total":        0,
+            "done":         0,
+            "ok":           0,
+            "failed":       0,
+            "current":      None,    # {"track_id": int, "title": str, "album": str}
+            "started_at":   None,
+            "finished_at":  None,
+            "backup_path":  None,    # where we wrote the pre-run fp dump
+            "last_error":   None,
+        }
 
 
 state = AppState()
@@ -3302,6 +3317,108 @@ async def update_album_metadata(album_id: int, body: Annotated[dict, Body()]):
     if not success:
         return {"ok": False, "error": "Album not found"}, 404
     return {"ok": True}
+
+
+# ── Maintenance: Rebuild Fingerprints ─────────────────────────────────────
+
+async def _rebuild_fingerprints_worker():
+    """Walk every playable track, re-extract its PCM slice from the side
+    FLAC, and replace its fingerprint rows.
+
+    Runs entirely off the event loop via run_in_executor; we just poke
+    progress state and broadcast on each track's completion. The hot
+    work (ffmpeg decode + fpcalc + DB write) is CPU/IO bound but cheap
+    enough on a Pi 5 to do all of it serially without thread-pool churn.
+    """
+    loop = asyncio.get_event_loop()
+    tracks = await loop.run_in_executor(None, cat.get_all_playable_tracks)
+    total = len(tracks)
+
+    state.rebuild_fp.update({
+        "in_progress":  True,
+        "total":        total,
+        "done":         0,
+        "ok":           0,
+        "failed":       0,
+        "current":      None,
+        "started_at":   time.time(),
+        "finished_at":  None,
+        "last_error":   None,
+    })
+
+    # Pre-run backup so a bad rebuild is reversible. Filename is timestamped
+    # so repeated rebuilds don't clobber each other.
+    backup_path = (
+        Path(__file__).parent / f"fingerprints_backup_{int(time.time())}.json"
+    )
+    try:
+        await loop.run_in_executor(
+            None, cat.backup_fingerprints_to, str(backup_path)
+        )
+        state.rebuild_fp["backup_path"] = str(backup_path)
+    except Exception as e:
+        state.rebuild_fp["last_error"] = f"Backup failed: {e}"
+        print(f"[rebuild-fp] Backup failed: {e}")
+
+    await broadcast("rebuild_fingerprints_progress", dict(state.rebuild_fp))
+
+    for t in tracks:
+        state.rebuild_fp["current"] = {
+            "track_id": t["track_id"],
+            "title":    t["track_title"],
+            "album":    t["album_title"],
+        }
+        try:
+            result = await loop.run_in_executor(
+                None,
+                cat.rebuild_track_fingerprints,
+                t["track_id"],
+                t["audio_path"],
+                float(t["start_secs"]),
+                float(t["end_secs"]),
+            )
+        except Exception as e:
+            result = {"ok": False, "rows": 0, "error": str(e)}
+
+        if result["ok"]:
+            state.rebuild_fp["ok"] += 1
+        else:
+            state.rebuild_fp["failed"] += 1
+            state.rebuild_fp["last_error"] = (
+                f"{t['album_title']}: {t['track_title']}: {result['error']}"
+            )
+        state.rebuild_fp["done"] += 1
+
+        # Broadcast every 5 tracks (or always on the last) to keep the WS
+        # quiet while still feeling responsive on a ~1000-track library.
+        if state.rebuild_fp["done"] % 5 == 0 or state.rebuild_fp["done"] == total:
+            await broadcast("rebuild_fingerprints_progress", dict(state.rebuild_fp))
+
+    state.rebuild_fp["in_progress"] = False
+    state.rebuild_fp["current"]     = None
+    state.rebuild_fp["finished_at"] = time.time()
+    await broadcast("rebuild_fingerprints_progress", dict(state.rebuild_fp))
+    print(
+        f"[rebuild-fp] Done: {state.rebuild_fp['ok']} ok / "
+        f"{state.rebuild_fp['failed']} failed out of {total}"
+    )
+
+
+@app.post("/api/maintenance/rebuild-fingerprints")
+async def rebuild_fingerprints_start():
+    """Kick off the full-library fingerprint rebuild. Returns immediately
+    with a 202-ish payload; progress is broadcast over WS and pollable
+    via the status endpoint."""
+    if state.rebuild_fp["in_progress"]:
+        return {"ok": False, "error": "Rebuild already in progress",
+                "progress": dict(state.rebuild_fp)}
+    spawn_bg(_rebuild_fingerprints_worker())
+    return {"ok": True, "started": True}
+
+
+@app.get("/api/maintenance/rebuild-fingerprints/status")
+async def rebuild_fingerprints_status():
+    return {"ok": True, "progress": dict(state.rebuild_fp)}
 
 
 # ── Feature 2: Duplicate Detection ────────────────────────────────────────

--- a/templates/index.html
+++ b/templates/index.html
@@ -2438,6 +2438,20 @@
             <div id="artwork-fetch-result" style="display:none;font-size:0.75rem;margin-top:0.3rem;line-height:1.4"></div>
           </div>
         </div>
+        <div class="settings-section"><h3>Library Maintenance</h3>
+          <p style="font-size:0.75rem;color:var(--muted);margin-bottom:0.4rem;line-height:1.4">Rebuild every track's audio fingerprint from its recorded audio. Useful after the recording or fingerprinting code changes. Pi 5: roughly 1-2 seconds per track. The current fingerprints are backed up to disk first.</p>
+          <div style="display:flex;gap:0.4rem;align-items:center;margin-bottom:0.4rem">
+            <button class="btn btn-accent" id="rebuild-fp-btn" onclick="startRebuildFingerprints()">Rebuild all fingerprints</button>
+            <span id="rebuild-fp-summary" style="font-size:0.72rem;color:var(--muted)"></span>
+          </div>
+          <div id="rebuild-fp-progress" style="display:none">
+            <div style="background:var(--muted-bg,rgba(128,128,128,0.15));border-radius:4px;overflow:hidden;height:6px;margin:0.3rem 0">
+              <div id="rebuild-fp-bar" style="height:100%;background:var(--amber);width:0%;transition:width 0.3s"></div>
+            </div>
+            <div id="rebuild-fp-label" style="font-size:0.72rem;color:var(--cream)"></div>
+          </div>
+          <div id="rebuild-fp-result" style="display:none;font-size:0.75rem;margin-top:0.3rem;line-height:1.4"></div>
+        </div>
         <div class="settings-section"><h3>Storage</h3>
           <div style="font-size:0.82rem;margin-bottom:0.3rem">Location: <strong id="storage-path">—</strong></div>
           <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.5rem">Free: <span id="storage-free">—</span> GB of <span id="storage-total">—</span> GB</div>
@@ -2879,6 +2893,7 @@ function handleEvent(d){
   if(d.event==='sync_progress')onSyncProgress(d);
   if(d.event==='artwork_fetch_progress')onArtworkFetchProgress(d);
   if(d.event==='export_progress')handleExportProgress(d);
+  if(d.event==='rebuild_fingerprints_progress')onRebuildFpProgress(d);
   if(d.eq)applyEQValues(d.eq.bass,d.eq.treble,d.eq.volume);
 }
 
@@ -5399,6 +5414,47 @@ function onSyncProgress(d){const bar=document.getElementById('discogs-sync-bar')
 async function startArtworkFetch(){const btn=document.getElementById('artwork-fetch-btn');btn.disabled=true;btn.textContent='Fetching...';document.getElementById('artwork-fetch-progress').style.display='block';document.getElementById('artwork-fetch-result').style.display='none';try{const r=await fetch('/api/catalog/artwork/fetch-missing',{method:'POST'}).then(r=>r.json());if(!r.ok){showError(r.error||'Failed');btn.disabled=false;btn.textContent='Fetch missing artwork';document.getElementById('artwork-fetch-progress').style.display='none'}}catch(e){showError('Failed: '+e.message);btn.disabled=false;btn.textContent='Fetch missing artwork';document.getElementById('artwork-fetch-progress').style.display='none'}}
 function onArtworkFetchProgress(d){const bar=document.getElementById('artwork-fetch-bar');const label=document.getElementById('artwork-fetch-label');const pct=d.total>0?Math.round((d.checked/d.total)*100):0;bar.style.width=pct+'%';if(d.state==='running'||d.state==='starting'){label.textContent='Fetching '+d.checked+' of '+d.total+(d.current_album?' \u2014 '+d.current_album:'');label.style.color='var(--cream)'}if(d.state==='complete'){document.getElementById('artwork-fetch-progress').style.display='none';const res=document.getElementById('artwork-fetch-result');res.style.display='block';res.style.color='var(--sage)';var msg='Fetched <strong>'+d.fetched+'</strong> cover'+(d.fetched!==1?'s':'');if(d.failed>0)msg+=', <span style="color:var(--rust)">'+d.failed+' failed</span>';if(d.still_missing>0){msg+=' ('+d.still_missing+' album'+(d.still_missing!==1?'s':'')+' still missing artwork)';res.style.color='var(--amber)'}res.innerHTML=msg;const btn=document.getElementById('artwork-fetch-btn');btn.disabled=false;btn.textContent='Fetch missing artwork';if(d.fetched>0)loadCatalog()}if(d.state==='error'){document.getElementById('artwork-fetch-progress').style.display='none';const res=document.getElementById('artwork-fetch-result');res.style.display='block';res.style.color='var(--rust)';res.textContent='Error: '+(d.errors&&d.errors[0]||'unknown');const btn=document.getElementById('artwork-fetch-btn');btn.disabled=false;btn.textContent='Fetch missing artwork'}}
 function updateStorageInfo(storage){if(!storage)return;document.getElementById('storage-path').textContent=storage.path||'—';document.getElementById('storage-free').textContent=storage.free_gb||'—';document.getElementById('storage-total').textContent=storage.total_gb||'—'}
+
+// ── Library Maintenance: Rebuild Fingerprints ──
+async function startRebuildFingerprints(){
+  if(!confirm('Re-run fingerprint extraction on every track in your library? Current fingerprints are backed up first. This takes ~1-2 seconds per track on the Pi 5 and will use one CPU core for the duration.'))return;
+  var btn=document.getElementById('rebuild-fp-btn');
+  btn.disabled=true;btn.textContent='Starting…';
+  document.getElementById('rebuild-fp-result').style.display='none';
+  document.getElementById('rebuild-fp-progress').style.display='block';
+  try{
+    var r=await fetch('/api/maintenance/rebuild-fingerprints',{method:'POST'}).then(r=>r.json());
+    if(!r.ok){showError(r.error||'Could not start rebuild');btn.disabled=false;btn.textContent='Rebuild all fingerprints';document.getElementById('rebuild-fp-progress').style.display='none'}
+  }catch(e){
+    showError('Rebuild failed to start: '+e.message);btn.disabled=false;btn.textContent='Rebuild all fingerprints';document.getElementById('rebuild-fp-progress').style.display='none';
+  }
+}
+
+function onRebuildFpProgress(d){
+  var bar=document.getElementById('rebuild-fp-bar');
+  var label=document.getElementById('rebuild-fp-label');
+  var btn=document.getElementById('rebuild-fp-btn');
+  if(!bar||!label||!btn)return;
+  var pct=d.total>0?Math.round((d.done/d.total)*100):0;
+  bar.style.width=pct+'%';
+  if(d.in_progress){
+    btn.disabled=true;btn.textContent='Rebuilding…';
+    var cur=d.current?(' — '+(d.current.album||'')+': '+(d.current.title||'')):'';
+    label.textContent='Rebuilt '+d.done+' / '+d.total+' ('+d.ok+' ok, '+d.failed+' failed)'+cur;
+    label.style.color='var(--cream)';
+  }else if(d.finished_at){
+    document.getElementById('rebuild-fp-progress').style.display='none';
+    var res=document.getElementById('rebuild-fp-result');
+    res.style.display='block';
+    res.style.color=d.failed>0?'var(--amber)':'var(--sage)';
+    var msg='Rebuilt <strong>'+d.ok+'</strong> track'+(d.ok!==1?'s':'');
+    if(d.failed>0)msg+=', <span style="color:var(--rust)">'+d.failed+' failed</span>';
+    msg+=' (backup saved to '+(d.backup_path||'?')+')';
+    if(d.last_error&&d.failed>0)msg+='<br><span style="font-size:0.7rem;color:var(--muted)">Last error: '+esc(d.last_error)+'</span>';
+    res.innerHTML=msg;
+    btn.disabled=false;btn.textContent='Rebuild all fingerprints';
+  }
+}
 async function changeStoragePath(){const p=document.getElementById('new-storage-path').value.trim();if(!p){alert('Enter a path');return}if(!confirm('Move all recordings to '+p+'?'))return;const st=document.getElementById('storage-status');st.style.display='block';st.style.color='var(--muted)';st.textContent='Moving files…';try{const r=await fetch('/api/settings/storage',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({path:p})}).then(r=>r.json());if(r.ok){st.style.color='var(--sage)';st.textContent=r.message;document.getElementById('new-storage-path').value='';const d=await fetch('/api/status').then(r=>r.json());if(d.storage)updateStorageInfo(d.storage)}else{st.style.color='var(--rust)';st.textContent=r.error||'Failed'}}catch(e){st.style.color='var(--rust)';st.textContent='Error: '+e.message}}
 var _dirPickerPath='/';
 function openDirPicker(){


### PR DESCRIPTION
Older recordings sometimes have noticeably worse fingerprint quality than newer ones because the fingerprinting code was tuned after they were captured. This adds a Settings → Library Maintenance button that re-runs Chromaprint extraction against every track in the catalog and replaces the stored fingerprints.

## How it works

- For each row in `catalog.get_all_playable_tracks()`, ffmpeg seeks into the side FLAC at the track's `start_secs` and emits just that segment as WAV on stdout.
- That WAV feeds the same `fingerprint_wav` helper used at initial recording time, so the new fingerprints are exactly what current recordings produce.
- `save_track_fingerprints` replaces the track's rows atomically (DELETE + INSERT of full + sliced windows).

## Safety

- Before any DB write, the full `fingerprints` table is dumped to a timestamped JSON file in the repo dir (`fingerprints_backup_<unix>.json`). Path is shown in the UI result message so rollback is obvious.
- One track at a time. Pi 5 estimate: ~1-2 seconds per track including ffmpeg + fpcalc + DB write.
- Progress is broadcast over WS as `rebuild_fingerprints_progress` events every 5 tracks (and always on the last).

## UI

- New "Library Maintenance" section in Settings with a button, progress bar, current-track display, and final ok/failed summary.
- `POST /api/maintenance/rebuild-fingerprints` starts the worker via `spawn_bg` (no GC'd-task leak); returns an error payload if a rebuild is already in flight.
- `GET /api/maintenance/rebuild-fingerprints/status` returns the current progress for any client that missed the WS stream.

Doesn't touch playback while running. Lint + compile green.